### PR TITLE
feat: add confirmation dialog for file removal

### DIFF
--- a/src/imguiclient/imguiapp.cpp
+++ b/src/imguiclient/imguiapp.cpp
@@ -2380,6 +2380,36 @@ void ImGuiApp::FileManagerDescriptorPdbConfig(ProgramFileDescriptor &descriptor)
     }
 }
 
+void ShowRemoveFileConfirmationPopup(bool &erased)
+{
+    ImGui::OpenPopup("Remove File?");
+
+    // Center the modal popup
+    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+
+    if (ImGui::BeginPopupModal("Remove File?", NULL, ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        ImGui::TextUnformatted(
+            "Are you sure you want to remove this file from the list?\nIt does not delete it from disk.\n\n");
+
+        // #TODO: Add "Don't ask me next time" checkbox with persistent state
+
+        if (ImGui::Button("OK", ImVec2(120, 0)))
+        {
+            erased = true;
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::SetItemDefaultFocus();
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", ImVec2(120, 0)))
+        {
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
+    }
+}
+
 void ImGuiApp::FileManagerDescriptorActions(ProgramFileDescriptor &descriptor, bool &erased)
 {
     // Action buttons
@@ -2394,32 +2424,7 @@ void ImGuiApp::FileManagerDescriptorActions(ProgramFileDescriptor &descriptor, b
 
         if (ImGui::Button("Remove"))
         {
-            ImGui::OpenPopup("Remove File?");
-        }
-
-        // Center the modal popup
-        ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-        ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
-
-        if (ImGui::BeginPopupModal("Remove File?", NULL, ImGuiWindowFlags_AlwaysAutoResize))
-        {
-            ImGui::Text("Are you sure you want to remove this file?\nThis operation cannot be undone!\n\n");
-            ImGui::Separator();
-
-            // #TODO: Add "Don't ask me next time" checkbox with persistent state
-
-            if (ImGui::Button("OK", ImVec2(120, 0)))
-            {
-                erased = true;
-                ImGui::CloseCurrentPopup();
-            }
-            ImGui::SetItemDefaultFocus();
-            ImGui::SameLine();
-            if (ImGui::Button("Cancel", ImVec2(120, 0)))
-            {
-                ImGui::CloseCurrentPopup();
-            }
-            ImGui::EndPopup();
+            ShowRemoveFileConfirmationPopup(erased);
         }
     }
 

--- a/src/imguiclient/imguiapp.cpp
+++ b/src/imguiclient/imguiapp.cpp
@@ -1646,7 +1646,7 @@ void ImGuiApp::save_config_async(ProgramFileDescriptor *descriptor)
         descriptor->m_revisionDescriptor->m_exeConfigFilenameCopy = descriptor->m_exeConfigFilename;
         next_command = next_command->chain(
             [descriptor, revisionDescriptor = descriptor->m_revisionDescriptor](WorkQueueResultPtr &result) mutable
-            -> WorkQueueCommandPtr { return create_save_exe_config_command(revisionDescriptor); });
+                -> WorkQueueCommandPtr { return create_save_exe_config_command(revisionDescriptor); });
     }
 
     if (descriptor->can_save_pdb_config())
@@ -1654,7 +1654,7 @@ void ImGuiApp::save_config_async(ProgramFileDescriptor *descriptor)
         descriptor->m_revisionDescriptor->m_pdbConfigFilenameCopy = descriptor->m_pdbConfigFilename;
         next_command = next_command->chain(
             [descriptor, revisionDescriptor = descriptor->m_revisionDescriptor](WorkQueueResultPtr &result) mutable
-            -> WorkQueueCommandPtr { return create_save_pdb_config_command(revisionDescriptor); });
+                -> WorkQueueCommandPtr { return create_save_pdb_config_command(revisionDescriptor); });
     }
 
     assert(head_command.next_delayed_command != nullptr);
@@ -2391,10 +2391,36 @@ void ImGuiApp::FileManagerDescriptorActions(ProgramFileDescriptor &descriptor, b
         // Change text color too to make it readable with the light ImGui color theme.
         ImScoped::StyleColor text_color1(ImGuiCol_Text, ImVec4(1.00f, 1.00f, 1.00f, 1.00f));
         ImScoped::StyleColor text_color2(ImGuiCol_TextDisabled, ImVec4(0.50f, 0.50f, 0.50f, 1.00f));
-        erased = ImGui::Button("Remove");
 
-        // #TODO: Guard this button press with a confirmation dialog ?
-        // There is an example for this in "Dear ImGui Demo" > "Popups & Modal windows" > "Modals".
+        if (ImGui::Button("Remove"))
+        {
+            ImGui::OpenPopup("Remove File?");
+        }
+
+        // Center the modal popup
+        ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+        ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+
+        if (ImGui::BeginPopupModal("Remove File?", NULL, ImGuiWindowFlags_AlwaysAutoResize))
+        {
+            ImGui::Text("Are you sure you want to remove this file?\nThis operation cannot be undone!\n\n");
+            ImGui::Separator();
+
+            // #TODO: Add "Don't ask me next time" checkbox with persistent state
+
+            if (ImGui::Button("OK", ImVec2(120, 0)))
+            {
+                erased = true;
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::SetItemDefaultFocus();
+            ImGui::SameLine();
+            if (ImGui::Button("Cancel", ImVec2(120, 0)))
+            {
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::EndPopup();
+        }
     }
 
     ImGui::SameLine();
@@ -2412,6 +2438,7 @@ void ImGuiApp::FileManagerDescriptorActions(ProgramFileDescriptor &descriptor, b
             load_async(&descriptor);
         }
     }
+
     ImGui::SameLine();
     {
         ImScoped::Disabled disabled(!descriptor.can_save_config());

--- a/src/imguiclient/imguiapp.cpp
+++ b/src/imguiclient/imguiapp.cpp
@@ -1367,12 +1367,13 @@ void ImGuiApp::FileManagerDescriptorPdbConfig(ProgramFileDescriptor &descriptor)
     }
 }
 
-void ImGuiApp::ShowRemoveFileConfirmationPopup(bool &erased)
+bool ImGuiApp::ShowRemoveFileConfirmationPopup()
 {
     // Center the modal popup
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
     ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
 
+    bool confirmed = false;
     if (ImGui::BeginPopupModal("Remove File?", NULL, ImGuiWindowFlags_AlwaysAutoResize))
     {
         ImGui::TextWrapped("Are you sure you want to remove this file from the list? It does not delete it from disk.");
@@ -1383,7 +1384,7 @@ void ImGuiApp::ShowRemoveFileConfirmationPopup(bool &erased)
         float buttonWidth = ImGui::GetContentRegionAvail().x; // Get available width
         if (ImGui::Button("OK", buttonSize))
         {
-            erased = true;
+            confirmed = true;
             ImGui::CloseCurrentPopup();
         }
         ImGui::SetItemDefaultFocus();
@@ -1395,6 +1396,7 @@ void ImGuiApp::ShowRemoveFileConfirmationPopup(bool &erased)
 
         ImGui::EndPopup();
     }
+    return confirmed;
 }
 
 void ImGuiApp::FileManagerDescriptorActions(ProgramFileDescriptor &descriptor, bool &erased)
@@ -1413,7 +1415,9 @@ void ImGuiApp::FileManagerDescriptorActions(ProgramFileDescriptor &descriptor, b
         {
             ImGui::OpenPopup("Remove File?");
         }
-        ShowRemoveFileConfirmationPopup(erased);
+        bool confirmed = ShowRemoveFileConfirmationPopup();
+        if(confirmed)
+            erased = true;
     }
 
     ImGui::SameLine();

--- a/src/imguiclient/imguiapp.cpp
+++ b/src/imguiclient/imguiapp.cpp
@@ -1369,7 +1369,6 @@ void ImGuiApp::FileManagerDescriptorPdbConfig(ProgramFileDescriptor &descriptor)
 
 bool ImGuiApp::ShowRemoveFileConfirmationPopup()
 {
-    // Center the modal popup
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
     ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
 
@@ -1377,11 +1376,10 @@ bool ImGuiApp::ShowRemoveFileConfirmationPopup()
     if (ImGui::BeginPopupModal("Remove File?", NULL, ImGuiWindowFlags_AlwaysAutoResize))
     {
         ImGui::TextWrapped("Are you sure you want to remove this file from the list? It does not delete it from disk.");
-        ImGui::Spacing(); // Add some space between the text and buttons
+        ImGui::Spacing();
 
-        // Center the buttons
-        ImVec2 buttonSize(120, 0); // Width of 120, height auto
-        float buttonWidth = ImGui::GetContentRegionAvail().x; // Get available width
+        ImVec2 buttonSize(120, 0);
+        float buttonWidth = ImGui::GetContentRegionAvail().x;
         if (ImGui::Button("OK", buttonSize))
         {
             confirmed = true;
@@ -1416,7 +1414,7 @@ void ImGuiApp::FileManagerDescriptorActions(ProgramFileDescriptor &descriptor, b
             ImGui::OpenPopup("Remove File?");
         }
         bool confirmed = ShowRemoveFileConfirmationPopup();
-        if(confirmed)
+        if (confirmed)
             erased = true;
     }
 

--- a/src/imguiclient/imguiapp.cpp
+++ b/src/imguiclient/imguiapp.cpp
@@ -1365,16 +1365,27 @@ void ImGuiApp::FileManagerDescriptorPdbConfig(ProgramFileDescriptor &descriptor)
 bool ImGuiApp::ShowRemoveFileConfirmationPopup()
 {
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-    ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+
+    const char *message = "Are you sure you want to remove this file from the list? It does not delete it from disk.";
+    const float minWidth = 300.0f;
+    ImGui::SetNextWindowSizeConstraints(ImVec2(minWidth, 0), ImVec2(FLT_MAX, FLT_MAX));
 
     bool confirmed = false;
     if (ImGui::BeginPopupModal("Remove File?", NULL, ImGuiWindowFlags_AlwaysAutoResize))
     {
-        ImGui::TextWrapped("Are you sure you want to remove this file from the list? It does not delete it from disk.");
+        ImGui::TextWrapped(message);
         ImGui::Spacing();
 
-        ImVec2 buttonSize(120, 0);
-        float buttonWidth = ImGui::GetContentRegionAvail().x;
+        float availWidth = ImGui::GetContentRegionAvail().x;
+        float buttonWidth = ImMin(120.0f, (availWidth - ImGui::GetStyle().ItemSpacing.x) / 2);
+        ImVec2 buttonSize(buttonWidth, 0);
+
+        float buttonsWidth = buttonWidth * 2 + ImGui::GetStyle().ItemSpacing.x;
+        float indent = (availWidth - buttonsWidth) * 0.5f;
+        if (indent > 0.0f)
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + indent);
+
         if (ImGui::Button("OK", buttonSize))
         {
             confirmed = true;

--- a/src/imguiclient/imguiapp.cpp
+++ b/src/imguiclient/imguiapp.cpp
@@ -1222,7 +1222,7 @@ void ImGuiApp::FileManagerBody()
             {
                 bool erased;
                 FileManagerDescriptor(descriptor, erased);
-                if (erased)
+                if (erased && erase_idx == size_t(~0))
                     erase_idx = i;
 
                 if (m_showFileManagerWithTabs)

--- a/src/imguiclient/imguiapp.cpp
+++ b/src/imguiclient/imguiapp.cpp
@@ -649,7 +649,7 @@ void ImGuiApp::save_config_async(ProgramFileDescriptor *descriptor)
         descriptor->m_revisionDescriptor->m_exeConfigFilenameCopy = descriptor->m_exeConfigFilename;
         next_command = next_command->chain(
             [descriptor, revisionDescriptor = descriptor->m_revisionDescriptor](WorkQueueResultPtr &result) mutable
-                -> WorkQueueCommandPtr { return create_save_exe_config_command(revisionDescriptor); });
+            -> WorkQueueCommandPtr { return create_save_exe_config_command(revisionDescriptor); });
     }
 
     if (descriptor->can_save_pdb_config())
@@ -657,7 +657,7 @@ void ImGuiApp::save_config_async(ProgramFileDescriptor *descriptor)
         descriptor->m_revisionDescriptor->m_pdbConfigFilenameCopy = descriptor->m_pdbConfigFilename;
         next_command = next_command->chain(
             [descriptor, revisionDescriptor = descriptor->m_revisionDescriptor](WorkQueueResultPtr &result) mutable
-                -> WorkQueueCommandPtr { return create_save_pdb_config_command(revisionDescriptor); });
+            -> WorkQueueCommandPtr { return create_save_pdb_config_command(revisionDescriptor); });
     }
 
     assert(head_command.next_delayed_command != nullptr);
@@ -1226,7 +1226,7 @@ void ImGuiApp::FileManagerBody()
             {
                 bool erased;
                 FileManagerDescriptor(descriptor, erased);
-                if (erased && erase_idx == size_t(~0))
+                if (erased)
                     erase_idx = i;
 
                 if (m_showFileManagerWithTabs)
@@ -1366,29 +1366,30 @@ void ImGuiApp::FileManagerDescriptorPdbConfig(ProgramFileDescriptor &descriptor)
     }
 }
 
-bool ImGuiApp::ShowRemoveFileConfirmationPopup()
+bool ImGuiApp::ShowRemoveFileConfirmationPopup(const char *name)
 {
-    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
-
-    const char *message = "Are you sure you want to remove this file from the list? It does not delete it from disk.";
-    const float minWidth = 300.0f;
-    ImGui::SetNextWindowSizeConstraints(ImVec2(minWidth, 0), ImVec2(FLT_MAX, FLT_MAX));
-
     bool confirmed = false;
-    if (ImGui::BeginPopupModal("Remove File?", NULL, ImGuiWindowFlags_AlwaysAutoResize))
+
+    const ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSizeConstraints(ImVec2(300.0f, 0.0f), ImVec2(FLT_MAX, FLT_MAX));
+
+    if (ImGui::BeginPopupModal(name, NULL, ImGuiWindowFlags_AlwaysAutoResize))
     {
-        ImGui::TextWrapped(message);
+        ImGui::TextWrapped("Are you sure you want to remove this file from the list? It does not delete it from disk.");
         ImGui::Spacing();
 
-        float availWidth = ImGui::GetContentRegionAvail().x;
-        float buttonWidth = ImMin(120.0f, (availWidth - ImGui::GetStyle().ItemSpacing.x) / 2);
-        ImVec2 buttonSize(buttonWidth, 0);
+        const float availWidth = ImGui::GetContentRegionAvail().x;
+        const float buttonWidth = ImMin(120.0f, (availWidth - ImGui::GetStyle().ItemSpacing.x) / 2);
+        const ImVec2 buttonSize(buttonWidth, 0.0f);
 
-        float buttonsWidth = buttonWidth * 2 + ImGui::GetStyle().ItemSpacing.x;
-        float indent = (availWidth - buttonsWidth) * 0.5f;
+        // Center the 2 buttons in the dialog.
+        const float buttonsWidth = buttonWidth * 2 + ImGui::GetStyle().ItemSpacing.x;
+        const float indent = (availWidth - buttonsWidth) * 0.5f;
         if (indent > 0.0f)
+        {
             ImGui::SetCursorPosX(ImGui::GetCursorPosX() + indent);
+        }
 
         if (ImGui::Button("OK", buttonSize))
         {
@@ -1411,21 +1412,22 @@ void ImGuiApp::FileManagerDescriptorActions(ProgramFileDescriptor &descriptor, b
 {
     // Action buttons
     {
-        // Change button color.
-        ImScoped::StyleColor color1(ImGuiCol_Button, (ImVec4)ImColor::HSV(0.0f, 0.0f, 0.2f));
-        ImScoped::StyleColor color2(ImGuiCol_ButtonHovered, (ImVec4)ImColor::HSV(0.0f, 0.0f, 0.3f));
-        ImScoped::StyleColor color3(ImGuiCol_ButtonActive, (ImVec4)ImColor::HSV(0.0f, 0.0f, 0.4f));
-        // Change text color too to make it readable with the light ImGui color theme.
-        ImScoped::StyleColor text_color1(ImGuiCol_Text, ImVec4(1.00f, 1.00f, 1.00f, 1.00f));
-        ImScoped::StyleColor text_color2(ImGuiCol_TextDisabled, ImVec4(0.50f, 0.50f, 0.50f, 1.00f));
-
-        if (ImGui::Button("Remove"))
+        constexpr char *popupName = "Remove File?";
         {
-            ImGui::OpenPopup("Remove File?");
+            // Change button color.
+            ImScoped::StyleColor color1(ImGuiCol_Button, (ImVec4)ImColor::HSV(0.0f, 0.0f, 0.2f));
+            ImScoped::StyleColor color2(ImGuiCol_ButtonHovered, (ImVec4)ImColor::HSV(0.0f, 0.0f, 0.3f));
+            ImScoped::StyleColor color3(ImGuiCol_ButtonActive, (ImVec4)ImColor::HSV(0.0f, 0.0f, 0.4f));
+            // Change text color too to make it readable with the light ImGui color theme.
+            ImScoped::StyleColor text_color1(ImGuiCol_Text, ImVec4(1.00f, 1.00f, 1.00f, 1.00f));
+            ImScoped::StyleColor text_color2(ImGuiCol_TextDisabled, ImVec4(0.50f, 0.50f, 0.50f, 1.00f));
+
+            if (Button("Remove"))
+            {
+                ImGui::OpenPopup(popupName);
+            }
         }
-        bool confirmed = ShowRemoveFileConfirmationPopup();
-        if (confirmed)
-            erased = true;
+        erased = ShowRemoveFileConfirmationPopup(popupName);
     }
 
     ImGui::SameLine();

--- a/src/imguiclient/imguiapp.cpp
+++ b/src/imguiclient/imguiapp.cpp
@@ -2384,26 +2384,28 @@ void ImGuiApp::ShowRemoveFileConfirmationPopup(bool &erased)
 {
     // Center the modal popup
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
 
     if (ImGui::BeginPopupModal("Remove File?", NULL, ImGuiWindowFlags_AlwaysAutoResize))
     {
-        ImGui::TextUnformatted(
-            "Are you sure you want to remove this file from the list?\nIt does not delete it from disk.\n\n");
+        ImGui::TextWrapped("Are you sure you want to remove this file from the list? It does not delete it from disk.");
+        ImGui::Spacing(); // Add some space between the text and buttons
 
-        // #TODO: Add "Don't ask me next time" checkbox with persistent state
-
-        if (ImGui::Button("OK", ImVec2(120, 0)))
+        // Center the buttons
+        ImVec2 buttonSize(120, 0); // Width of 120, height auto
+        float buttonWidth = ImGui::GetContentRegionAvail().x; // Get available width
+        if (ImGui::Button("OK", buttonSize))
         {
             erased = true;
             ImGui::CloseCurrentPopup();
         }
         ImGui::SetItemDefaultFocus();
         ImGui::SameLine();
-        if (ImGui::Button("Cancel", ImVec2(120, 0)))
+        if (ImGui::Button("Cancel", buttonSize))
         {
             ImGui::CloseCurrentPopup();
         }
+
         ImGui::EndPopup();
     }
 }

--- a/src/imguiclient/imguiapp.cpp
+++ b/src/imguiclient/imguiapp.cpp
@@ -2380,10 +2380,8 @@ void ImGuiApp::FileManagerDescriptorPdbConfig(ProgramFileDescriptor &descriptor)
     }
 }
 
-void ShowRemoveFileConfirmationPopup(bool &erased)
+void ImGuiApp::ShowRemoveFileConfirmationPopup(bool &erased)
 {
-    ImGui::OpenPopup("Remove File?");
-
     // Center the modal popup
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
     ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
@@ -2424,8 +2422,9 @@ void ImGuiApp::FileManagerDescriptorActions(ProgramFileDescriptor &descriptor, b
 
         if (ImGui::Button("Remove"))
         {
-            ShowRemoveFileConfirmationPopup(erased);
+            ImGui::OpenPopup("Remove File?");
         }
+        ShowRemoveFileConfirmationPopup(erased);
     }
 
     ImGui::SameLine();

--- a/src/imguiclient/imguiapp.h
+++ b/src/imguiclient/imguiapp.h
@@ -281,7 +281,7 @@ private:
     static bool TreeNodeHeader(const char *str_id, ImGuiTreeNodeFlags flags, const char *fmt, ...) IM_FMTARGS(3);
     static void TreeNodeHeaderStyleColor(ScopedStyleColor &styleColor);
 
-    bool ShowRemoveFileConfirmationPopup();
+    bool ShowRemoveFileConfirmationPopup(const char *name);
 
 private:
     ImVec2 m_windowPos = ImVec2(0, 0);

--- a/src/imguiclient/imguiapp.h
+++ b/src/imguiclient/imguiapp.h
@@ -208,7 +208,7 @@ private:
         ScopedStyleColor &styleColor,
         const ProgramComparisonDescriptor::File::ListItemUiInfo &uiInfo);
 
-    void ShowRemoveFileConfirmationPopup(bool &erased);
+    bool ShowRemoveFileConfirmationPopup();
 
 private:
     ImVec2 m_windowPos = ImVec2(0, 0);

--- a/src/imguiclient/imguiapp.h
+++ b/src/imguiclient/imguiapp.h
@@ -526,6 +526,8 @@ private:
         ScopedStyleColor &styleColor,
         const ProgramComparisonDescriptor::File::ListItemUiInfo &uiInfo);
 
+    void ShowRemoveFileConfirmationPopup(bool &erased);
+
 private:
     ImVec2 m_windowPos = ImVec2(0, 0);
     ImVec2 m_windowSize = ImVec2(0, 0);

--- a/src/imguiclient/processedstate.h
+++ b/src/imguiclient/processedstate.h
@@ -15,6 +15,7 @@
 
 #include "commontypes.h"
 #include "util/bitarray.h"
+#include <vector>
 
 namespace unassemblize::gui
 {

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -564,7 +564,7 @@ NamedFunctionBundle Runner::build_bundle(
     const Address64ToIndexMapT &named_function_to_index_map,
     uint8_t flags)
 {
-    const SourceInfoVectorT::value_type &source = sources[source_idx];
+    const typename SourceInfoVectorT::value_type &source = sources[source_idx];
     const IndexT function_count = source.functionIds.size();
     NamedFunctionBundle bundle;
     bundle.id = source_idx;

--- a/src/util.h
+++ b/src/util.h
@@ -110,7 +110,7 @@ bool push_back_unique(Container &container, const Value &value)
 template<typename Container, typename Value>
 bool find_and_erase(Container &container, const Value &value)
 {
-    Container::iterator it = std::find(container.begin(), container.end(), value);
+    typename Container::iterator it = std::find(container.begin(), container.end(), value);
     if (it != container.end())
     {
         container.erase(it);
@@ -122,7 +122,7 @@ bool find_and_erase(Container &container, const Value &value)
 template<typename Container, typename UnaryPred>
 bool find_and_erase_if(Container &container, UnaryPred pred)
 {
-    Container::iterator it = std::find_if(container.begin(), container.end(), pred);
+    typename Container::iterator it = std::find_if(container.begin(), container.end(), pred);
     if (it != container.end())
     {
         container.erase(it);


### PR DESCRIPTION
Added a modal popup that requires user confirmation before removing files in the File Manager. This prevents accidental file deletions by requiring explicit user confirmation.